### PR TITLE
Rename to remove example name, deploy in deploy-tools stack

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,9 +48,8 @@ jobs:
       - name: Upload to riff-raff
         uses: guardian/actions-riff-raff@v1
         with:
-          app: ssm-to-env-lambda-example
           buildNumber: ${{ env.GITHUB_RUN_NUMBER }}
-          projectName: playground::ssm-to-env-lambda-example
+          projectName: deploy::ssm-to-env
           configPath: riff-raff.yml
     env:
       NODE_OPTIONS: '--max_old_space_size=4096'

--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,10 @@ node_modules
 dist
 .DS_Store
 
+# Exclude go binaries
+wrapper-script/nest-secrets-*
+
+
 # CDK asset staging directory
 .cdk.staging
 cdk.out

--- a/README.md
+++ b/README.md
@@ -1,8 +1,20 @@
-# ssm-to-env-lambda-example
+# ssm-to-env
 
 **WARNING:** This is a work in progress.
 
-This repository is intended to test including a [lambda layer]() as a mechanism to pull configuration from from an SSM prefix and make it available as environment variables within the lambda.
+This repository contains an [AWS Lambda layer](https://docs.aws.amazon.com/lambda/latest/dg/configuration-layers.html) which pulls configuration from an SSM prefix and makes it available as environment variables within the lambda.
+
+It does this by adding the [guardian/nest-secrets](https://github.com/guardian/nest-secrets) application to your lambda, and uses the `SSM_PATH_PREFIX` environment variable as the SSM prefix to look up.
+
+## How to use
+
+...
+
+## How to develop
+
+...
+
+## Notes
 
 This approach hopes to combine this [AWS layer example](https://github.com/aws-samples/aws-lambda-environmental-variables-from-aws-secrets-manager), with some of the functionality of [guardian/nest-secrets](https://github.com/guardian/nest-secrets).
 

--- a/packages/cdk/bin/cdk.ts
+++ b/packages/cdk/bin/cdk.ts
@@ -1,11 +1,11 @@
 import 'source-map-support/register';
 import { App } from 'aws-cdk-lib';
-import { SsmToEnvLambdaExample } from '../lib/ssm-to-env-lambda-example';
+import { SsmToEnv } from '../lib/ssm-to-env';
 
 const app = new App();
-new SsmToEnvLambdaExample(app, 'SsmToEnvLambdaExample-CODE', {
+new SsmToEnv(app, 'SsmToEnv-CODE', {
 	stack: 'playground',
 	stage: 'CODE',
-	app: 'ssm-to-env-lambda-example',
+	app: 'ssm-to-env',
 	vary: `${Math.floor(new Date().getTime() / 1000)}`,
 });

--- a/packages/cdk/bin/cdk.ts
+++ b/packages/cdk/bin/cdk.ts
@@ -3,9 +3,16 @@ import { App } from 'aws-cdk-lib';
 import { SsmToEnv } from '../lib/ssm-to-env';
 
 const app = new App();
-new SsmToEnv(app, 'SsmToEnv-CODE', {
-	stack: 'playground',
-	stage: 'CODE',
-	app: 'ssm-to-env',
-	vary: `${Math.floor(new Date().getTime() / 1000)}`,
+const stages = ['CODE', 'PROD'];
+
+// This value is used to ensure re-deployment of the lambda layer on each build
+const vary = `${Math.floor(new Date().getTime() / 1000)}`;
+
+stages.map((stage: string) => {
+	new SsmToEnv(app, `SsmToEnv-${stage}`, {
+		stack: 'deploy',
+		stage: stage,
+		app: 'ssm-to-env',
+		vary: vary,
+	});
 });

--- a/packages/cdk/jest.setup.js
+++ b/packages/cdk/jest.setup.js
@@ -1,1 +1,1 @@
-jest.mock("@guardian/cdk/lib/constants/tracking-tag");
+jest.mock('@guardian/cdk/lib/constants/tracking-tag');

--- a/packages/cdk/lib/__snapshots__/ssm-to-env.test.ts.snap
+++ b/packages/cdk/lib/__snapshots__/ssm-to-env.test.ts.snap
@@ -8,6 +8,11 @@ Object {
       "Description": "SSM parameter containing the S3 bucket name holding distribution artifacts",
       "Type": "AWS::SSM::Parameter::Value<String>",
     },
+    "organizationid": Object {
+      "Default": "/TEST/deploy/ssm-to-env/organization-id",
+      "Description": "(From SSM) The AWS organization id with which to share this layer",
+      "Type": "AWS::SSM::Parameter::Value<String>",
+    },
   },
   "Resources": Object {
     "getsecretslayer63FFACD4": Object {
@@ -23,6 +28,19 @@ Object {
       },
       "Type": "AWS::Lambda::LayerVersion",
     },
+    "getsecretslayerremoteaccountgrantC876FA0C": Object {
+      "Properties": Object {
+        "Action": "lambda:GetLayerVersion",
+        "LayerVersionArn": Object {
+          "Ref": "getsecretslayer63FFACD4",
+        },
+        "OrganizationId": Object {
+          "Ref": "organizationid",
+        },
+        "Principal": "*",
+      },
+      "Type": "AWS::Lambda::LayerVersionPermission",
+    },
     "ssmtoenvlambdaexample80E45003": Object {
       "DependsOn": Array [
         "ssmtoenvlambdaexampleServiceRoleDefaultPolicy4EA1D11C",
@@ -33,13 +51,13 @@ Object {
           "S3Bucket": Object {
             "Ref": "DistributionBucketName",
           },
-          "S3Key": "deploy/TEST/ssm-to-env-lambda-example/ssm-to-env-lambda-example.zip",
+          "S3Key": "deploy/TEST/ssm-to-env/ssm-to-env-lambda-example.zip",
         },
         "Environment": Object {
           "Variables": Object {
-            "APP": "ssm-to-env-lambda-example",
+            "APP": "ssm-to-env",
             "AWS_LAMBDA_EXEC_WRAPPER": "/opt/ssm-to-env.sh",
-            "SSM_PATH_PREFIX": "/CODE/playground/ssm-to-env-lambda-example",
+            "SSM_PATH_PREFIX": "/TEST/deploy/ssm-to-env-lambda-example",
             "STACK": "deploy",
             "STAGE": "TEST",
           },
@@ -61,7 +79,7 @@ Object {
         "Tags": Array [
           Object {
             "Key": "App",
-            "Value": "ssm-to-env-lambda-example",
+            "Value": "ssm-to-env",
           },
           Object {
             "Key": "gu:cdk:version",
@@ -69,7 +87,7 @@ Object {
           },
           Object {
             "Key": "gu:repo",
-            "Value": "guardian/ssm-to-env-lambda-example",
+            "Value": "guardian/ssm-to-env",
           },
           Object {
             "Key": "Stack",
@@ -115,7 +133,7 @@ Object {
         "Tags": Array [
           Object {
             "Key": "App",
-            "Value": "ssm-to-env-lambda-example",
+            "Value": "ssm-to-env",
           },
           Object {
             "Key": "gu:cdk:version",
@@ -123,7 +141,7 @@ Object {
           },
           Object {
             "Key": "gu:repo",
-            "Value": "guardian/ssm-to-env-lambda-example",
+            "Value": "guardian/ssm-to-env",
           },
           Object {
             "Key": "Stack",
@@ -197,7 +215,7 @@ Object {
                     Object {
                       "Ref": "AWS::AccountId",
                     },
-                    ":parameter/TEST/deploy/ssm-to-env-lambda-example",
+                    ":parameter/TEST/deploy/ssm-to-env",
                   ],
                 ],
               },
@@ -220,7 +238,7 @@ Object {
                     Object {
                       "Ref": "AWS::AccountId",
                     },
-                    ":parameter/TEST/deploy/ssm-to-env-lambda-example/*",
+                    ":parameter/TEST/deploy/ssm-to-env/*",
                   ],
                 ],
               },

--- a/packages/cdk/lib/__snapshots__/ssm-to-env.test.ts.snap
+++ b/packages/cdk/lib/__snapshots__/ssm-to-env.test.ts.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`The SsmToEnvLambdaExample stack matches the snapshot 1`] = `
+exports[`The SsmToEnv stack matches the snapshot 1`] = `
 Object {
   "Parameters": Object {
     "DistributionBucketName": Object {

--- a/packages/cdk/lib/__snapshots__/ssm-to-env.test.ts.snap
+++ b/packages/cdk/lib/__snapshots__/ssm-to-env.test.ts.snap
@@ -57,7 +57,7 @@ Object {
           "Variables": Object {
             "APP": "ssm-to-env",
             "AWS_LAMBDA_EXEC_WRAPPER": "/opt/ssm-to-env.sh",
-            "SSM_PATH_PREFIX": "/TEST/deploy/ssm-to-env-lambda-example",
+            "SSM_PATH_PREFIX": "/TEST/deploy/ssm-to-env",
             "STACK": "deploy",
             "STAGE": "TEST",
           },

--- a/packages/cdk/lib/__snapshots__/ssm-to-env.test.ts.snap
+++ b/packages/cdk/lib/__snapshots__/ssm-to-env.test.ts.snap
@@ -16,7 +16,7 @@ Object {
           "S3Bucket": Object {
             "Ref": "DistributionBucketName",
           },
-          "S3Key": "playground/TEST/ssm-to-env-lambda-example/ssm-to-env-lambda-layer-example.zip",
+          "S3Key": "deploy/TEST/ssm-to-env/ssm-to-env.zip",
         },
         "Description": "This layer is used to pull config from SSM and convert to environmental variables",
         "LayerName": "ssm-to-env-layer-nope",
@@ -33,14 +33,14 @@ Object {
           "S3Bucket": Object {
             "Ref": "DistributionBucketName",
           },
-          "S3Key": "playground/TEST/ssm-to-env-lambda-example/ssm-to-env-lambda-example.zip",
+          "S3Key": "deploy/TEST/ssm-to-env-lambda-example/ssm-to-env-lambda-example.zip",
         },
         "Environment": Object {
           "Variables": Object {
             "APP": "ssm-to-env-lambda-example",
             "AWS_LAMBDA_EXEC_WRAPPER": "/opt/ssm-to-env.sh",
             "SSM_PATH_PREFIX": "/CODE/playground/ssm-to-env-lambda-example",
-            "STACK": "playground",
+            "STACK": "deploy",
             "STAGE": "TEST",
           },
         },
@@ -73,7 +73,7 @@ Object {
           },
           Object {
             "Key": "Stack",
-            "Value": "playground",
+            "Value": "deploy",
           },
           Object {
             "Key": "Stage",
@@ -127,7 +127,7 @@ Object {
           },
           Object {
             "Key": "Stack",
-            "Value": "playground",
+            "Value": "deploy",
           },
           Object {
             "Key": "Stage",
@@ -197,7 +197,7 @@ Object {
                     Object {
                       "Ref": "AWS::AccountId",
                     },
-                    ":parameter/TEST/playground/ssm-to-env-lambda-example",
+                    ":parameter/TEST/deploy/ssm-to-env-lambda-example",
                   ],
                 ],
               },
@@ -220,7 +220,7 @@ Object {
                     Object {
                       "Ref": "AWS::AccountId",
                     },
-                    ":parameter/TEST/playground/ssm-to-env-lambda-example/*",
+                    ":parameter/TEST/deploy/ssm-to-env-lambda-example/*",
                   ],
                 ],
               },

--- a/packages/cdk/lib/ssm-to-env.test.ts
+++ b/packages/cdk/lib/ssm-to-env.test.ts
@@ -6,9 +6,9 @@ describe('The SsmToEnv stack', () => {
 	it('matches the snapshot', () => {
 		const app = new App();
 		const stack = new SsmToEnv(app, 'SsmToEnv', {
-			stack: 'playground',
+			stack: 'deploy',
 			stage: 'TEST',
-			app: 'ssm-to-env-lambda-example',
+			app: 'ssm-to-env',
 			vary: 'nope',
 		});
 		const template = Template.fromStack(stack);

--- a/packages/cdk/lib/ssm-to-env.test.ts
+++ b/packages/cdk/lib/ssm-to-env.test.ts
@@ -1,11 +1,11 @@
 import { App } from 'aws-cdk-lib';
 import { Template } from 'aws-cdk-lib/assertions';
-import { SsmToEnvLambdaExample } from './ssm-to-env-lambda-example';
+import { SsmToEnv } from './ssm-to-env';
 
-describe('The SsmToEnvLambdaExample stack', () => {
+describe('The SsmToEnv stack', () => {
 	it('matches the snapshot', () => {
 		const app = new App();
-		const stack = new SsmToEnvLambdaExample(app, 'SsmToEnvLambdaExample', {
+		const stack = new SsmToEnv(app, 'SsmToEnv', {
 			stack: 'playground',
 			stage: 'TEST',
 			app: 'ssm-to-env-lambda-example',

--- a/packages/cdk/lib/ssm-to-env.ts
+++ b/packages/cdk/lib/ssm-to-env.ts
@@ -48,13 +48,13 @@ export class SsmToEnv extends GuStack {
 
 		const lambdaName = 'ssm-to-env-lambda-example';
 		new GuLambdaFunction(this, lambdaName, {
-			app: 'ssm-to-env',
+			app: props.app,
 			fileName: 'ssm-to-env-lambda-example.zip',
 			runtime: Runtime.NODEJS_16_X,
 			handler: 'index.handler',
 			environment: {
 				AWS_LAMBDA_EXEC_WRAPPER: '/opt/ssm-to-env.sh',
-				SSM_PATH_PREFIX: `/${this.stage}/${this.stack}/${lambdaName}`,
+				SSM_PATH_PREFIX: `/${this.stage}/${this.stack}/${props.app}`,
 			},
 			layers: [getSecretsLayer],
 		});

--- a/packages/cdk/lib/ssm-to-env.ts
+++ b/packages/cdk/lib/ssm-to-env.ts
@@ -8,13 +8,13 @@ import type { App } from 'aws-cdk-lib';
 import { Code, LayerVersion, Runtime } from 'aws-cdk-lib/aws-lambda';
 import { Bucket } from 'aws-cdk-lib/aws-s3';
 
-interface SsmToEnvLambdaStackProps extends GuStackProps {
+interface SsmToEnvStackProps extends GuStackProps {
 	app: string;
 	vary: string;
 }
 
-export class SsmToEnvLambdaExample extends GuStack {
-	constructor(scope: App, id: string, props: SsmToEnvLambdaStackProps) {
+export class SsmToEnv extends GuStack {
+	constructor(scope: App, id: string, props: SsmToEnvStackProps) {
 		super(scope, id, props);
 
 		const bucket = Bucket.fromBucketName(

--- a/packages/cdk/lib/ssm-to-env.ts
+++ b/packages/cdk/lib/ssm-to-env.ts
@@ -26,10 +26,7 @@ export class SsmToEnv extends GuStack {
 		const keyPrefix = `${this.stack}/${this.stage}/${props.app}`;
 
 		const getSecretsLayer = new LayerVersion(this, 'get-secrets-layer', {
-			code: Code.fromBucket(
-				bucket,
-				`${keyPrefix}/ssm-to-env-lambda-layer-example.zip`,
-			),
+			code: Code.fromBucket(bucket, `${keyPrefix}/ssm-to-env.zip`),
 			layerVersionName: `ssm-to-env-layer-${props.vary}`,
 			description:
 				'This layer is used to pull config from SSM and convert to environmental variables',

--- a/riff-raff.yml
+++ b/riff-raff.yml
@@ -1,18 +1,18 @@
 regions: [eu-west-1]
-stacks: [playground]
+stacks: [deploy]
 deployments:
   lambda-to-s3:
     type: aws-s3
-    app: ssm-to-env-lambda-example
+    app: ssm-to-env
     sources:
       - packages/lambda/dist/ssm-to-env-lambda-example.zip
-      - wrapper-script/ssm-to-env-lambda-layer-example.zip
+      - wrapper-script/ssm-to-env.zip
     parameters:
-      bucket: developer-playground-dist
+      bucket: deploy-tools-dist
       cacheControl: no-cache
       publicReadAcl: false
       prefixApp: true
-  ssm-to-env-lambda-example:
+  ssm-to-env:
     type: aws-lambda
     dependencies: [cdk-cloudformation]
     actions:
@@ -24,11 +24,11 @@ deployments:
   cdk-cloudformation:
     type: cloud-formation
     sources:
-      - packages/cdk/cdk.out/SsmToEnvLambdaExample-CODE.template.json
-    app: ssm-to-env-lambda-example
+      - packages/cdk/cdk.out/SsmToEnv-CODE.template.json
+    app: ssm-to-env
     parameters:
       prependStackToCloudFormationStackName: false
-      cloudFormationStackName: ssm-to-env-lambda-example
+      cloudFormationStackName: ssm-to-env
       templateStagePaths:
-        CODE: SsmToEnvLambdaExample-CODE.template.json
+        CODE: SsmToEnv-CODE.template.json
       cloudFormationStackByTags: false

--- a/script/ci.sh
+++ b/script/ci.sh
@@ -28,4 +28,4 @@ popd
 
 cp ${ROOT_DIR}/nest-secrets/bin/* ${layer_dist_dir}
 
-zip -FSjr "${layer_dist_dir}/ssm-to-env-lambda-layer-example.zip" "${layer_dist_dir}"
+zip -FSjr "${layer_dist_dir}/ssm-to-env.zip" "${layer_dist_dir}"

--- a/wrapper-script/README.md
+++ b/wrapper-script/README.md
@@ -3,7 +3,7 @@
 You can test this script by retrieving credentials from Janus and running:
 
 ```sh
-SSM_PATH_PREFIX=/CODE/deploy/ssm-to-env-lambda-example \
+SSM_PATH_PREFIX=/CODE/deploy/ssm-to-env \
 AWS_PROFILE=deployTools \
 ./ssm-to-env.sh node ../packages/lambda/dist/index.js
 ```

--- a/wrapper-script/README.md
+++ b/wrapper-script/README.md
@@ -3,7 +3,7 @@
 You can test this script by retrieving credentials from Janus and running:
 
 ```sh
-SSM_PATH_PREFIX=/CODE/playground/ssm-to-env-lambda-example \
-AWS_PROFILE=developerPlayground \
+SSM_PATH_PREFIX=/CODE/deploy/ssm-to-env-lambda-example \
+AWS_PROFILE=deployTools \
 ./ssm-to-env.sh node ../packages/lambda/dist/index.js
 ```

--- a/wrapper-script/README.md
+++ b/wrapper-script/README.md
@@ -1,0 +1,9 @@
+# wrapper-script
+
+You can test this script by retrieving credentials from Janus and running:
+
+```sh
+SSM_PATH_PREFIX=/CODE/playground/ssm-to-env-lambda-example \
+AWS_PROFILE=developerPlayground \
+./ssm-to-env.sh node ../packages/lambda/dist/index.js
+```

--- a/wrapper-script/ssm-to-env.sh
+++ b/wrapper-script/ssm-to-env.sh
@@ -7,7 +7,7 @@ args=("$@")
 prefix="${SSM_PATH_PREFIX}"
 
 # The name of this script
-name=$(basename $0)
+name=$(basename $0 .sh)
 
 # The full path to this script
 fullPath="$( cd -- "$(dirname "$0")" >/dev/null 2>&1 ; pwd -P )"


### PR DESCRIPTION
## What does this change?

This repository will become the production use repo for ssm-to-env (keeping the example lambda). This change renames things appropriately and changes the stack from dev-playground to deploy-tools.