### PR TITLE
Update build process (remove git submodules)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,10 +38,6 @@ jobs:
           node-version-file: '.nvmrc'
           cache: 'npm'
 
-      - uses: actions/setup-go@v3
-        with:
-          go-version-file: 'nest-secrets/go.mod'
-
       - name: Run script/ci
         run: ./script/ci.sh
 

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,0 @@
-[submodule "nest-secrets"]
-	path = nest-secrets
-	url = git@github.com:guardian/nest-secrets.git
-	branch = quotes-n-hyphens

--- a/README.md
+++ b/README.md
@@ -1,22 +1,39 @@
 # ssm-to-env
 
-**WARNING:** This is a work in progress.
-
 This repository contains an [AWS Lambda layer](https://docs.aws.amazon.com/lambda/latest/dg/configuration-layers.html) which pulls configuration from an SSM prefix and makes it available as environment variables within the lambda.
 
 It does this by adding the [guardian/nest-secrets](https://github.com/guardian/nest-secrets) application to your lambda, and uses the `SSM_PATH_PREFIX` environment variable as the SSM prefix to look up.
 
 ## How to use
 
-...
+This layer can be used in lambdas to automate the process of configuring your lambdas by making [AWS SSM Parameters](https://docs.aws.amazon.com/systems-manager/latest/userguide/systems-manager-parameter-store.html) at a specified prefix available as environment variables to your lambda.
+
+This lambda layer is configured to be available to all Guardian AWS repositories so you only need specify its [ARN in your lambda configuration](packages/cdk/lib/ssm-to-env.ts).
+
+The layer expects the following environment variables to be set in order to function:
+
+```sh
+AWS_LAMBDA_EXEC_WRAPPER: '/opt/ssm-to-env.sh',
+SSM_PATH_PREFIX: `/CODE/my_stack/my_app`
+```
+
+`AWS_LAMBDA_EXEC_WRAPPER` is required [aws lambda configuration](https://docs.aws.amazon.com/lambda/latest/dg/runtimes-modify.html) specifying what needs to be executed in the packaged layer.
 
 ## How to develop
 
-...
+There are instructions for [testing the wrapper script](wrapper-script/README.md), which will execute the [test lambda] using that script locally, this should reproduce what happens when a lambda layer is used in AWS by a consuming lambda.
+
+To get started run (you'll need [node](https://nodejs.org/en/download/) and [nvm](https://github.com/nvm-sh/nvm)):
+
+```sh
+nvm use
+npm install
+npm run build
+```
 
 ## Notes
 
-This approach hopes to combine this [AWS layer example](https://github.com/aws-samples/aws-lambda-environmental-variables-from-aws-secrets-manager), with some of the functionality of [guardian/nest-secrets](https://github.com/guardian/nest-secrets).
+This approach combines this [AWS layer example](https://github.com/aws-samples/aws-lambda-environmental-variables-from-aws-secrets-manager), with some of the functionality of [guardian/nest-secrets](https://github.com/guardian/nest-secrets).
 
 Lambda layers can be provisioned using [AWS CDK](https://github.com/aws-samples/aws-lambda-environmental-variables-from-aws-secrets-manager/blob/b8360682026ab6f4c3f48e61a9e342a3fd3b3c06/cdk/lib/cdk-stack.ts#L44) by referencing a file uploaded to S3, or via other mechanisms similar to a usual lambda deployment.
 

--- a/packages/cdk/README.md
+++ b/packages/cdk/README.md
@@ -3,3 +3,8 @@
 This directory defines the components to be deployed to AWS.
 
 See [`package.json`](./package.json) for a list of available scripts.
+
+It contains:
+
+- `ssm-to-env` [lambda layer](https://docs.aws.amazon.com/lambda/latest/dg/gettingstarted-concepts.html#gettingstarted-concepts-layer) which can be used in your lambdas to automate pulling configuration from SSM.
+- An example lambda to test the layer functionality locally and in AWS.

--- a/packages/lambda/README.md
+++ b/packages/lambda/README.md
@@ -1,0 +1,9 @@
+# Example lambda
+
+This is an example lambda to demonstrate the behavior of the `ssm-to-env` layer and to test the wrapper script functionality locally.
+
+It expects there to be a `test_output` parameter at the location in [AWS SSM Parameter Store](https://docs.aws.amazon.com/systems-manager/latest/userguide/systems-manager-parameter-store.html) specified by `SSM_PATH_PREFIX`.
+
+For example if you specify `SSM_PATH_PREFIX=/CODE/deploy/ssm-to-env` it will try and read the parameter at location `/CODE/deploy/ssm-to-env/test_output`.
+
+You can test this lambda by running the [wrapper script](../../wrapper-script/README.md).

--- a/packages/lambda/src/index.ts
+++ b/packages/lambda/src/index.ts
@@ -1,6 +1,14 @@
 export const handler = async (): Promise<void> => {
-	const varFromWrapper = process.env['test_output'] ?? 'unset';
-	console.log(`hello world: ${varFromWrapper}`);
+	const ssmPathPrefix = process.env['SSM_PATH_PREFIX'] ?? 'unset';
+	if (ssmPathPrefix == 'unset') {
+		throw new Error('SSM_PATH_PREFIX is unset, please provide a valid value!');
+	}
+
+	const unsetWarning = `The parameter 'test_output' is unset on SSM path ${ssmPathPrefix}`;
+	const varFromWrapper = process.env['test_output'] ?? unsetWarning;
+
+	console.log(`Reading 'test_output' parameter from ${ssmPathPrefix}`);
+	console.log(`Found: ${varFromWrapper}`);
 
 	await Promise.resolve();
 };

--- a/script/ci.sh
+++ b/script/ci.sh
@@ -9,7 +9,8 @@ ARCH="linux-amd64"
 
 RELEASE_VERSION=1.4.0
 GH_BASE_PATH="https://github.com/guardian/nest-secrets/releases/download"
-BINARY_LOCATION="${GH_BASE_PATH}/v${RELEASE_VERSION}/nest-secrets-${ARCH}"
+BINARY_NAME="nest-secrets-${ARCH}"
+BINARY_LOCATION="${GH_BASE_PATH}/v${RELEASE_VERSION}/${BINARY_NAME}}"
 
 npm ci
 npm run typecheck
@@ -27,7 +28,8 @@ layer_dist_dir="${ROOT_DIR}/wrapper-script"
 
 # Download binaries from nest-secrets GitHub release
 pushd ${layer_dist_dir}
-    wget $BINARY_LOCATION
+    wget -O $BINARY_NAME $BINARY_LOCATION
 popd
 
+# Compress the lambda layer package as a deployable asset
 zip -FSjr "${layer_dist_dir}/ssm-to-env.zip" "${layer_dist_dir}"

--- a/script/ci.sh
+++ b/script/ci.sh
@@ -10,7 +10,7 @@ ARCH="linux-amd64"
 RELEASE_VERSION=1.4.0
 GH_BASE_PATH="https://github.com/guardian/nest-secrets/releases/download"
 BINARY_NAME="nest-secrets-${ARCH}"
-BINARY_LOCATION="${GH_BASE_PATH}/v${RELEASE_VERSION}/${BINARY_NAME}}"
+BINARY_LOCATION="${GH_BASE_PATH}/v${RELEASE_VERSION}/${BINARY_NAME}"
 
 npm ci
 npm run typecheck

--- a/script/ci.sh
+++ b/script/ci.sh
@@ -5,6 +5,11 @@ set -x
 
 DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
 ROOT_DIR="${DIR}/.."
+ARCH="linux-amd64"
+
+RELEASE_VERSION=1.4.0
+GH_BASE_PATH="https://github.com/guardian/nest-secrets/releases/download"
+BINARY_LOCATION="${GH_BASE_PATH}/v${RELEASE_VERSION}/nest-secrets-${ARCH}"
 
 npm ci
 npm run typecheck
@@ -20,12 +25,9 @@ zip -FSjr "${lambda_dist_dir}/ssm-to-env-lambda-example.zip" "${lambda_dist_dir}
 # Package layer code
 layer_dist_dir="${ROOT_DIR}/wrapper-script"
 
-# Build & package nest-secrets
-pushd ${ROOT_DIR}/nest-secrets
-mkdir -p bin
-./build.sh
+# Download binaries from nest-secrets GitHub release
+pushd ${layer_dist_dir}
+    wget $BINARY_LOCATION
 popd
-
-cp ${ROOT_DIR}/nest-secrets/bin/* ${layer_dist_dir}
 
 zip -FSjr "${layer_dist_dir}/ssm-to-env.zip" "${layer_dist_dir}"

--- a/wrapper-script/README.md
+++ b/wrapper-script/README.md
@@ -4,14 +4,26 @@ You can test this script by:
 
 - Ensure you have downloaded the correct binary for your environment to this folder (on a new Apple laptop this will be `darwin-arm64`):
   
-```
-wget -O nest-secrets-darwin-arm6 https://github.com/guardian/nest-secrets/releases/download/v1.4.0/nest-secrets-darwin-arm64
+```sh
+# From this folder
+wget -O nest-secrets-darwin-arm64 https://github.com/guardian/nest-secrets/releases/download/v1.4.0/nest-secrets-darwin-arm64
 chmod u+x nest-secrets-darwin-arm64
+```
+
+- Build the example lambda:
+
+```sh
+# From the root of the repository
+nvm use
+npm install 
+npm run build
+cd wrapper-script
 ```
 
 - Retrieve credentials from Janus, specify the correct SSM prefix, architecture and run:
 
 ```sh
+# From this folder
 SSM_PATH_PREFIX=/CODE/deploy/ssm-to-env \
 AWS_PROFILE=deployTools \
 arch=darwin-arm64 \

--- a/wrapper-script/README.md
+++ b/wrapper-script/README.md
@@ -1,9 +1,19 @@
 # wrapper-script
 
-You can test this script by retrieving credentials from Janus and running:
+You can test this script by:
+
+- Ensure you have downloaded the correct binary for your environment to this folder (on a new Apple laptop this will be `darwin-arm64`):
+  
+```
+wget -O nest-secrets-darwin-arm6 https://github.com/guardian/nest-secrets/releases/download/v1.4.0/nest-secrets-darwin-arm64
+chmod u+x nest-secrets-darwin-arm64
+```
+
+- Retrieve credentials from Janus, specify the correct SSM prefix, architecture and run:
 
 ```sh
 SSM_PATH_PREFIX=/CODE/deploy/ssm-to-env \
 AWS_PROFILE=deployTools \
+arch=darwin-arm64 \
 ./ssm-to-env.sh node ../packages/lambda/dist/index.js
 ```

--- a/wrapper-script/ssm-to-env.sh
+++ b/wrapper-script/ssm-to-env.sh
@@ -12,11 +12,11 @@ name=$(basename $0 .sh)
 # The full path to this script
 fullPath="$( cd -- "$(dirname "$0")" >/dev/null 2>&1 ; pwd -P )"
 
-# Get architecture so we can choose the correct binary
-arch=$(uname | tr '[:upper:]' '[:lower:]')
+# Allow the arch to be handed in
+arch=${arch:-linux-amd64}
 
 # Write env vars to temporary file
-${fullPath}/nest-secrets-${arch}-amd64 --prefix ${prefix} > /tmp/${name}.env
+${fullPath}/nest-secrets-${arch} --prefix ${prefix} > /tmp/${name}.env
 
 # Export all the values to env vars
 set -o allexport
@@ -28,5 +28,3 @@ rm /tmp/${name}.env
 
 # Execute the next step
 exec ${args[@]}
-
-


### PR DESCRIPTION
## What does this change?

This updates the build process to pull the [nest-secrets](https://github.com/guardian/nest-secrets) binaries from the GitHub releases on that repository following https://github.com/guardian/nest-secrets/pull/4. Previously the `nest-secrets` binaries had been built in this repository via [git submodules](https://git-scm.com/book/en/v2/Git-Tools-Submodules) which was unnecessarily complex.

This change packages only a single binary targeting `linux-amd64` for use in AWS lambda, and modified the wrapper script documentation to describe how to test on `darwin` architectures (for developers with macbooks).

[Documentation is updated too](https://github.com/guardian/ssm-to-env/blob/dcb2154599ad0be4fc0ee110fc98a3f56e81850d/README.md) to make the repository more accessible.

## How to test

Local testing of `/build/ci.sh` indicates this works, the `ci` workflow will also be run by GitHub actions against this PR nd should pass.

## How can we measure success?

Can this layer be consumed successfully in a Lambda?

